### PR TITLE
Renamed "Prolog" option to "SessionProlog"

### DIFF
--- a/Kernel/MermaidJS.wl
+++ b/Kernel/MermaidJS.wl
@@ -33,7 +33,7 @@ MermaidJS::nss =
 
 Options[MermaidJS] =
     Join[{"MermaidOptions" -> "--pdfFit", "MermaidDirectives" -> "TD",
-      "ShellSession" -> Automatic, "Prolog" -> "source ~/.zshrc"},
+      "ShellSession" -> Automatic, "SessionProlog" -> "source ~/.zshrc"},
       Options[Graphics]];
 
 MermaidJS[mSpec : (_String | _Graph), opts : OptionsPattern[]] :=
@@ -69,7 +69,7 @@ MermaidJS[mSpec_String, typeArg : (_String | Automatic),
         type = "pdf"
       ];
 
-      sessionProlog = OptionValue[MermaidJS, "Prolog"];
+      sessionProlog = OptionValue[MermaidJS, "SessionProlog"];
       If[! StringQ[sessionProlog],
         ResourceFunction["ResourceFunctionMessage"][MermaidJS::nsp];
         sessionProlog = "";
@@ -100,7 +100,7 @@ MermaidJS[mSpec_String, typeArg : (_String | Automatic),
         command =
             "cat << EOF | mmdc -o " <> fname <> " -q -i - " <> mmdOpts <> "\n" <> mSpec <> "\nEOF";
 
-        res = ExternalEvaluate[<|"System" -> shellSession, "Prolog" -> sessionProlog|>, command];
+        res = ExternalEvaluate[<|"System" -> shellSession, "SessionProlog" -> sessionProlog|>, command];
       ];
 
       Which[


### PR DESCRIPTION
This solves issue #2 

"SessionProlog" is option recognized by the "Shell" External Evaluation System as documented here:
https://wolfram.com/xid/0gxr4tewogh7cm3zt00mrihebzse1-q1aw77

The Prolog option (no quotes) continues to be available for the resulting Graphic object.